### PR TITLE
fixed get_url_status() since it is using HTTP2 now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - asdf install sbt $LATEST_VERSION
   - asdf global sbt $LATEST_VERSION
   - asdf current sbt
-  - test `asdf current sbt | cut -d' ' -f1` = $LATEST_VERSION
+  - test `asdf current sbt | cut -d' ' -f14` = $LATEST_VERSION
   - asdf plugin-test sbt https://github.com/bram2000/asdf-sbt.git
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git

--- a/bin/install
+++ b/bin/install
@@ -84,8 +84,7 @@ get_download_url() {
 
 get_url_status() {
   local url="$1"
-  local status="$(curl -s -I "$url" | grep 'HTTP/1.1' | awk '{print $2}' | tail -n 1)"
-
+  local status="$(curl -s -o /dev/null -w "%{http_code}" "$url")"
   echo "$status"
 }
 


### PR DESCRIPTION
The error was easy to reproduce like this:
```
root@somewhere:~# asdf install sbt 1.0.4
The version specified was not found. Exiting
```
Even though the link was working. It may have been like this because https://github.com/sbt/sbt/releases/download was using HTTP/2 now and the grep of HTTP/1.1 did not work anymore.