### PR TITLE
Update exec-env for change in asdf current output

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,6 +2,6 @@
 
 # Shamelessly copied from https://github.com/Proemion/asdf-maven
 if asdf current java > /dev/null 2>&1 ; then
-  java_version=$(asdf current java | cut -f1 -d' ')
+  java_version=$(asdf current java | tr -s ' ' | cut -f2 -d' ')
   export JAVA_HOME=$(asdf where java "$java_version")
 fi


### PR DESCRIPTION
This change now properly selects the version field and deals with excess whitespace between fields